### PR TITLE
Wiz pathfind tile

### DIFF
--- a/src/systems/wizards/MovementAction.ts
+++ b/src/systems/wizards/MovementAction.ts
@@ -116,7 +116,11 @@ export class MovementAction {
     let legStart = this.path[legStartIndex];
     let legEnd = this.path[legStartIndex + 1];
     let legProgress = journeyProgress - legStartIndex;
-    return lerp(legStart, legEnd, legProgress);
+    if (legStartIndex + 1 >= this.path.length) {
+      return legStart;// end doesn't exist after arrival, start is final position
+    } else {
+      return lerp(legStart, legEnd, legProgress);
+    }
   }
 }
 

--- a/src/systems/wizards/MovementAction.ts
+++ b/src/systems/wizards/MovementAction.ts
@@ -10,6 +10,7 @@ export class MovementAction {
 
   startTile: Tile;
   endTile: Tile;
+  path: Phaser.Math.Vector2[];
 
   startPixelPosition: Phaser.Math.Vector2;
   endPixelPosition: Phaser.Math.Vector2;
@@ -47,7 +48,8 @@ export class MovementAction {
     );
 
     this.speed = speed;
-
+    
+    this.path = this.pathfind(startTile); 
     this.distance = this.startPixelPosition.distance(this.endPixelPosition);
     this.time = this.distance / this.speed;
 
@@ -55,6 +57,14 @@ export class MovementAction {
 
     this.complete = false;
     this.completeCallback = completeCallback;
+  }
+
+  private pathfind(startPoint: Tile) {
+    return [this.startPixelPosition, this.endPixelPosition];
+    let curPos = startPoint;
+    // for now just go in a circle around starting position
+    return this.hexGrid.getNeighbouringHexes(curPos.coordinates).map(pos =>
+    this.hexGrid.convertGridHexToPixelHex(pos));
   }
 
   public update(deltaTimeMs: number) {
@@ -68,17 +78,21 @@ export class MovementAction {
       return;
     }
 
-    let wizardPosition = lerp(
-      this.startPixelPosition,
-      this.endPixelPosition,
-      this.progress / this.time
-    );
-
     let wizardImage = this.wizard.getImage();
 
-    wizardImage.x = wizardPosition.x + this.hexGrid.getContainer().x;
-    wizardImage.y = wizardPosition.y + this.hexGrid.getContainer().y;
+    wizardImage.x = wizardPosition().x + this.hexGrid.getContainer().x;
+    wizardImage.y = wizardPosition().y + this.hexGrid.getContainer().y;
 
     wizardImage.depth = wizardImage.y;
   }
+
+  private wizardPosition(): Phaser.Math.Vector2 {
+    let journeyProgress = (this.progress / this.time) * this.path.length
+    let legStartIndex = Math.floor(journeyProgress)
+    let legStart = this.path[legStartIndex];
+    let legEnd = this.path[legStartIndex + 1];
+    let legProgress = journeyProgress - legStartIndex;
+    return lerp(legStart, legEnd, legProgress);
+  }
 }
+

--- a/src/systems/wizards/MovementAction.ts
+++ b/src/systems/wizards/MovementAction.ts
@@ -1,9 +1,10 @@
 import { lerp } from '../../helpers';
 import { HexagonGrid } from '../hex_grid/HexagonGrid';
-import { Tile } from '../world_generation/WorldModel';
+import { WorldModel, Tile } from '../world_generation/WorldModel';
 import { WizardEntity } from './Wizard';
 
 export class MovementAction {
+  worldModel: WorldModel;
   hexGrid: HexagonGrid;
 
   wizard: WizardEntity;
@@ -26,6 +27,7 @@ export class MovementAction {
   completeCallback: () => void;
 
   constructor(
+    worldModel: WorldModel,
     hexGrid: HexagonGrid,
     wizard: WizardEntity,
     startTile: Tile,
@@ -33,6 +35,7 @@ export class MovementAction {
     speed: number,
     completeCallback: () => void
   ) {
+    this.worldModel = worldModel;
     this.hexGrid = hexGrid;
 
     this.wizard = wizard;
@@ -70,7 +73,7 @@ export class MovementAction {
     const neighbours = (hex) => this.hexGrid.getNeighbouringHexes(hex);
     const hash = (hex) => "<" + hex.x + "," + hex.y + ">";
     const isNew = (hex) => paths[hash(hex)] === undefined;
-    const isWalkable = (hex) => true;//todo, need to index into worldmap for Tile info somehow
+    const isWalkable = (hex) => this.worldModel.getTile(hex).terrainData.is_walkable;
 
     paths[hash(start)] = [start];
     let curPass = [start];
@@ -104,8 +107,8 @@ export class MovementAction {
 
     let wizardImage = this.wizard.getImage();
 
-    wizardImage.x = wizardPosition().x + this.hexGrid.getContainer().x;
-    wizardImage.y = wizardPosition().y + this.hexGrid.getContainer().y;
+    wizardImage.x = this.wizardPosition().x + this.hexGrid.getContainer().x;
+    wizardImage.y = this.wizardPosition().y + this.hexGrid.getContainer().y;
 
     wizardImage.depth = wizardImage.y;
   }

--- a/src/systems/wizards/WizardManager.ts
+++ b/src/systems/wizards/WizardManager.ts
@@ -265,6 +265,7 @@ export class WizardManager {
     this.movingWizards.set(
       targetWizard,
       new MovementAction(
+        this.worldModel,
         this.hexGrid,
         targetWizard,
         currentTile,


### PR DESCRIPTION
When a movement action is moving a wizard to a tile, they will now respect the grid movement options, moving from the centre of one hex to the centre of another, avoiding lakes, until they find their destination tile.
Unsure of what the behaviour is when the destination is a lake. Potentially need to avoid creating a movement action for that tile.