### PR TITLE
basic gpt dialogue added with ui, loading includes lambda

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -48,10 +48,6 @@ export function App() {
     return () => unsubscribe();
   }, []);
 
-  const sendGameStateToPhaser = (gameState: GameData) => {
-    eventEmitter.emit('update-phaser-data', gameState);
-  };
-
   const buyWizard = (elementType: ElementType): void => {
     eventEmitter.emit('buy-wizard', elementType);
   };

--- a/src/components/EmpiresTab.tsx
+++ b/src/components/EmpiresTab.tsx
@@ -1,19 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
 import { Empire, WorldEvent } from '../types';
 
 import icon_tornado_event_src from '../assets/ui/event_icons/icon_tornado.png';
 import icon_fire_event_src from '../assets/ui/event_icons/icon_fire.png';
 import icon_earthquake_event_src from '../assets/ui/event_icons/icon_earthquake.png';
 import { getSeededPortraitForName } from '../setup/rulerPortraits';
+import { sendMessageToKingdom } from '../services';
+import { twMerge } from 'tailwind-merge';
 
 export const EmpiresTab: React.FC<{
   empires: Empire[];
   worldEvents: WorldEvent[];
 }> = (props) => {
+  const [empireInDialogue, setEmpireInDialogue] = useState<Empire | null>(null);
+
+  if (empireInDialogue !== null) {
+    return (
+      <EmpireDialogue
+        empire={empireInDialogue}
+        closeDialogue={() => setEmpireInDialogue(null)}
+      />
+    );
+  }
+
   return (
     <div className="h-full w-full flex flex-col items-start justify-start gap-y-1 p-2 max-h-[90vh] overflow-auto">
       <h2 className="text-2xl text-green-500 pb-2">Empires</h2>
       {props.empires.map((empire) => (
-        <EmpireStatus empire={empire} />
+        <EmpireStatus
+          empire={empire}
+          openDialogue={() => setEmpireInDialogue(empire)}
+        />
       ))}
       <h2 className="text-2xl text-green-500 pb-2">Arcane Anomalies</h2>
       {props.worldEvents.map((worldEvent) => (
@@ -23,8 +40,15 @@ export const EmpiresTab: React.FC<{
   );
 };
 
-export const EmpireStatus: React.FC<{ empire: Empire }> = (props) => {
-  const { empire } = props;
+type EmpireStatusProps = {
+  empire: Empire;
+  openDialogue: () => void;
+};
+
+export const EmpireStatus: React.FC<EmpireStatusProps> = (props) => {
+  const { empire, openDialogue } = props;
+
+  const apiEnabled = import.meta.env.VITE_API_ENABLED === 'true';
 
   let empireIconSource = getSeededPortraitForName(empire.rulerName);
 
@@ -51,8 +75,15 @@ export const EmpireStatus: React.FC<{ empire: Empire }> = (props) => {
         <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold mx-2 py-2 px-6 rounded">
           View Capital
         </button>
-        <button className="bg-emerald-600 hover:bg-emerald-800 text-white font-bold mx-2 py-2 px-6 rounded">
-          Open Dialogue
+        <button
+          className={twMerge(
+            'text-white font-bold mx-2 py-2 px-6 rounded',
+            apiEnabled ? 'bg-emerald-600 hover:bg-emerald-800' : 'bg-gray-500'
+          )}
+          onClick={() => openDialogue()}
+          disabled={!apiEnabled}
+        >
+          {apiEnabled ? 'Open Dialogue' : 'Chat Disabled'}
         </button>
       </div>
     </div>
@@ -100,6 +131,92 @@ export const WorldEventStatus: React.FC<{ worldEvent: WorldEvent }> = (
       <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
         Go To
       </button>
+    </div>
+  );
+};
+
+type EmpireDialogueProps = {
+  empire: Empire;
+  closeDialogue: () => void;
+};
+
+const EmpireDialogue: React.FC<EmpireDialogueProps> = (props) => {
+  const { empire, closeDialogue } = props;
+  const [inputValue, setInputValue] = useState('');
+  const [messageHistory, setMessageHistory] = useState(empire.messageHistory);
+  const messageEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messageEndRef.current?.scrollIntoView({ behavior: 'instant' });
+  }, [messageHistory]);
+
+  const submitMessage = async (inputValue: string) => {
+    empire.messageHistory.push({
+      message: inputValue,
+      sender: 'user',
+      timestamp: Date.now(),
+    });
+    setMessageHistory([...empire.messageHistory]);
+
+    setInputValue('');
+
+    const response = await sendMessageToKingdom(empire, inputValue);
+
+    if (response) {
+      empire.messageHistory.push({
+        message: response.message.content,
+        sender: 'empire',
+        timestamp: Date.now(),
+      });
+      setMessageHistory([...empire.messageHistory]);
+    }
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col items-start justify-start gap-y-1 p-2">
+      <h2 className="text-2xl text-green-500 pb-2">{empire.rulerName}</h2>
+      <div className="flex flex-col w-full h-full max-h-[75vh] bg-slate-400 border-gray-800 rounded-lg border-2 p-2 gap-y-2 justify-end">
+        <div className="flex flex-col overflow-auto gap-y-2">
+          {empire.messageHistory.map((message, index) => (
+            <div
+              key={index}
+              className={`w-[80%] px-1 rounded-md  ${
+                message.sender === 'user'
+                  ? 'self-end bg-slate-200'
+                  : 'self-start bg-indigo-200'
+              }`}
+            >
+              <p className="text-sm text-gray-700 text-pretty">
+                {message.message}
+              </p>
+            </div>
+          ))}
+          <div ref={messageEndRef} className="-mt-2"></div>
+        </div>
+        <input
+          className="w-full bg-gray-200 p-2 rounded"
+          type="text"
+          onKeyPress={(e) =>
+            e.key === 'Enter' ? submitMessage(inputValue) : undefined
+          }
+          value={inputValue}
+          onChange={(e) => setInputValue((e.target as HTMLInputElement).value)}
+        />
+        <div className="flex flex-col gap-y-2">
+          <button
+            className="bg-emerald-600 hover:bg-emerald-800 text-white font-bold py-2 px-6 rounded"
+            onClick={() => submitMessage(inputValue)}
+          >
+            Send Message
+          </button>
+          <button
+            className="bg-emerald-600 hover:bg-emerald-800 text-white font-bold py-2 px-6 rounded"
+            onClick={() => closeDialogue()}
+          >
+            Close Dialogue
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/EmpiresTab.tsx
+++ b/src/components/EmpiresTab.tsx
@@ -162,6 +162,16 @@ const EmpireDialogue: React.FC<EmpireDialogueProps> = (props) => {
 
     const response = await sendMessageToKingdom(empire, inputValue);
 
+    if (response === 'error') {
+      empire.messageHistory.push({
+        message: 'The crow never returned. (server error)',
+        sender: 'system',
+        timestamp: Date.now(),
+      });
+      setMessageHistory([...empire.messageHistory]);
+      return;
+    }
+
     if (response) {
       empire.messageHistory.push({
         message: response.message.content,
@@ -169,6 +179,19 @@ const EmpireDialogue: React.FC<EmpireDialogueProps> = (props) => {
         timestamp: Date.now(),
       });
       setMessageHistory([...empire.messageHistory]);
+    }
+  };
+
+  const getMessageFormat = (sender: string) => {
+    switch (sender) {
+      case 'user':
+        return 'self-end bg-slate-200 text-gray-700';
+      case 'empire':
+        return 'self-start bg-indigo-200 text-gray-700';
+      case 'system':
+        return 'self-center bg-white text-red-500';
+      default:
+        return 'self-start bg-indigo-200 text-gray-700';
     }
   };
 
@@ -180,15 +203,9 @@ const EmpireDialogue: React.FC<EmpireDialogueProps> = (props) => {
           {empire.messageHistory.map((message, index) => (
             <div
               key={index}
-              className={`w-[80%] px-1 rounded-md  ${
-                message.sender === 'user'
-                  ? 'self-end bg-slate-200'
-                  : 'self-start bg-indigo-200'
-              }`}
+              className={`w-[80%] px-1 rounded-md  ${getMessageFormat(message.sender)}`}
             >
-              <p className="text-sm text-gray-700 text-pretty">
-                {message.message}
-              </p>
+              <p className="text-sm text-pretty">{message.message}</p>
             </div>
           ))}
           <div ref={messageEndRef} className="-mt-2"></div>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -18,8 +18,7 @@ export const sendMessageToKingdom = async (empire: Empire, message: string) => {
         method: 'POST',
         body: JSON.stringify({
           message: message,
-          personality: empire.personality,
-          playerReputation: empire.playerReputation,
+          empire: empire,
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -35,8 +34,10 @@ export const sendMessageToKingdom = async (empire: Empire, message: string) => {
         'Error sending message to kingdom. Status: ',
         response.status
       );
+      return 'error';
     }
   } catch (error) {
     console.error('Error sending message to kingdom.');
+    return 'error';
   }
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,42 @@
+import { Empire } from '../types';
+
+type SendMessageToKingdomResponse = {
+  index: number;
+  message: {
+    role: string;
+    content: string;
+  };
+  logprobs: null | any;
+  finish_reason: string;
+};
+
+export const sendMessageToKingdom = async (empire: Empire, message: string) => {
+  try {
+    const response = await fetch(
+      import.meta.env.VITE_AWS_API_URL + '/dialogue',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          message: message,
+          personality: empire.personality,
+          playerReputation: empire.playerReputation,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (response.ok) {
+      const responseBody: SendMessageToKingdomResponse = await response.json();
+      return responseBody;
+    } else {
+      console.error(
+        'Error sending message to kingdom. Status: ',
+        response.status
+      );
+    }
+  } catch (error) {
+    console.error('Error sending message to kingdom.');
+  }
+};

--- a/src/systems/empires/EmpireSystem.ts
+++ b/src/systems/empires/EmpireSystem.ts
@@ -144,17 +144,16 @@ export class EmpiresSystem {
   }
 
   public getRandomPersonality(): EmpirePersonality {
-    switch (this.randomGenerator.between(0, 3)) {
-      case 0:
-        return 'passive';
-      case 1:
-        return 'aggressive';
-      case 2:
-        return 'friendly';
-      case 3:
-        return 'selfish';
-    }
+    const personalities: EmpirePersonality[] = [
+      'megalomaniacal',
+      'erratic',
+      'passive',
+      'friendly',
+      'greedy',
+      'selfish',
+      'reclusive',
+    ];
 
-    return 'passive';
+    return personalities[this.randomGenerator.between(0, personalities.length)];
   }
 }

--- a/src/systems/empires/EmpireSystem.ts
+++ b/src/systems/empires/EmpireSystem.ts
@@ -75,9 +75,10 @@ export class EmpiresSystem {
           empireSettings.minStartSize,
           empireSettings.maxStartSize
         ),
-        playerReputation: 50,
+        playerReputation: 5,
         personality: this.getRandomPersonality(),
         color: empireColours[i],
+        messageHistory: [],
       };
 
       gameState.empires.push(empire);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,8 +48,15 @@ export type Empire = {
   rulerName: string;
   regionalStrength: number;
   playerReputation: number;
+  messageHistory: Message[];
   personality: EmpirePersonality;
   color: number;
+};
+
+export type Message = {
+  message: string;
+  sender: 'user' | 'empire';
+  timestamp: number;
 };
 
 export type Mission = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,7 +55,7 @@ export type Empire = {
 
 export type Message = {
   message: string;
-  sender: 'user' | 'empire';
+  sender: 'user' | 'empire' | 'system';
   timestamp: number;
 };
 
@@ -96,10 +96,13 @@ export type Wizard = {
 };
 
 export type EmpirePersonality =
-  | 'aggressive'
+  | 'megalomaniacal'
+  | 'erratic'
   | 'passive'
   | 'friendly'
-  | 'selfish';
+  | 'greedy'
+  | 'selfish'
+  | 'reclusive';
 
 export type ElementType = 'fire' | 'water' | 'earth' | 'air';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,8 @@ import preact from '@preact/preset-vite';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [preact()],
+  define: {
+    'process.env': process.env,
+  },
 });
+


### PR DESCRIPTION
Implements gpt dialogue in the empires list:
- open dialogue opens a chat with that kingdom, including any previous message history
- open dialogue is disabled if the API is not enabled (an .env)
- loading screen will now be instant if the API is disabled, otherwise it waits for a response from the lambda /warmup endpoint first

The gpt prompt is very basic at the moment + doesnt remember conversation. I'll improve this by sending more data + message history and returning stat changes in future MRs.

We might want to set up a useContext in the future - it can be a pain, but most of our state is modified in the scopes of the components themselves, not the whole state at the moment (don't see any issues yet as the phaser data is unrelated and we send it there anyway)